### PR TITLE
fix alignment of original char

### DIFF
--- a/content.js
+++ b/content.js
@@ -64,7 +64,7 @@ function convertToPinyinAndDisplay(textNodes) {
 
                         newContent += `<span style="display: inline-block; text-align: center;" class="pinyinOverlayText">
                     <span style="display: block; font-size: smaller; color: ${lessSaturatedColor};">&nbsp;${pinyinWord}&nbsp;</span>
-                    ${originalChar}
+                    <span style="display: block;">${originalChar}</span>
                 </span>`; // Adding a non-breaking space character (&nbsp) so there's space between pinyin words.
                     } else {
                         newContent += originalChar;


### PR DESCRIPTION
Fixed alignment of original char. 
See the comparison between the correct first 2 chars, and incorrect last 2 chars.
![image](https://github.com/MrAnderson1971/pinyin-extension/assets/86937926/f2a1259c-83a3-47c9-8e06-e966041f5db9)